### PR TITLE
chore(package): remove uneeded i18n packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,8 +60,6 @@
     "@carbon/ibmdotcom-web-components": "^1.6.0",
     "@carbon/type": "^10.13.0",
     "carbon-web-components": "^1.7.1",
-    "handlebars-i18n": "^1.2.1",
-    "i18next": "^20.3.2",
     "intl": "^1.2.5",
     "lit-element": "^2.4.0",
     "lit-html": "^1.3.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -834,7 +834,7 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.0", "@babel/runtime@^7.12.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
+"@babel/runtime@^7.11.2", "@babel/runtime@^7.12.1", "@babel/runtime@^7.5.0", "@babel/runtime@^7.8.0", "@babel/runtime@^7.8.4", "@babel/runtime@^7.9.2":
   version "7.14.6"
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.14.6.tgz#535203bc0892efc7dec60bdc27b2ecf6e409062d"
   integrity sha512-/PCB2uJ7oM44tz8YhC4Z/6PeOKXp4K588f+5M3clr1M4zbqztlo0XEfJ2LEzj/FgwfgGcIdl8n7YYjTCI0BYwg==
@@ -5264,15 +5264,6 @@ handle-thing@^2.0.0:
   resolved "https://registry.yarnpkg.com/handle-thing/-/handle-thing-2.0.1.tgz#857f79ce359580c340d43081cc648970d0bb234e"
   integrity sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==
 
-handlebars-i18n@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/handlebars-i18n/-/handlebars-i18n-1.2.1.tgz#413fc34c0a98466d82074ad4e5c3b7174b36e38d"
-  integrity sha512-lpIR6c9aIn5Yny0Ajz4t4I8svOrEuaqVDe2Zdgx2cyI8RykLzabV+rtrH4uBQeiyRVNbLdBt2VhPQLOSVDawvg==
-  dependencies:
-    handlebars "^4.7.6"
-    i18next "^20.2.1"
-    intl "^1.2.5"
-
 handlebars-loader@^1.7.0:
   version "1.7.1"
   resolved "https://registry.yarnpkg.com/handlebars-loader/-/handlebars-loader-1.7.1.tgz#07088f09d8a559344908f7c88c68c0ffdacc555d"
@@ -5283,7 +5274,7 @@ handlebars-loader@^1.7.0:
     loader-utils "1.0.x"
     object-assign "^4.1.0"
 
-handlebars@^4.7.6, handlebars@^4.7.7:
+handlebars@^4.7.7:
   version "4.7.7"
   resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
   integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
@@ -5659,13 +5650,6 @@ husky@^4.3.0:
     please-upgrade-node "^3.2.0"
     slash "^3.0.0"
     which-pm-runs "^1.0.0"
-
-i18next@^20.2.1, i18next@^20.3.2:
-  version "20.3.2"
-  resolved "https://registry.yarnpkg.com/i18next/-/i18next-20.3.2.tgz#5195e76b9e0848a1c198001bf6c7fc72995a55f1"
-  integrity sha512-e8CML2R9Ng2sSQOM80wb/PrM2j8mDm84o/T4Amzn9ArVyNX5/ENWxxAXkRpZdTQNDaxKImF93Wep4mAoozFrKw==
-  dependencies:
-    "@babel/runtime" "^7.12.0"
 
 iconv-lite@0.4.24, iconv-lite@^0.4.17:
   version "0.4.24"


### PR DESCRIPTION
### Related Ticket(s)
None.

### Description
The `handlebars-i18n` and `i18next` packages are leftovers from the initial template configurations; they are not needed now.

### Changelog

**Removed**

- the `i18n` packages that are not needed